### PR TITLE
EE-19858 added a correlation id to stats ui requests 

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "express": "^4.16.4",
     "request": "^2.88.0",
+    "uuid": "^3.3.2",
     "winston": "^3.2.1"
   },
   "devDependencies": {

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const fs = require('fs');
 const request = require('request');
+const uuid = require('uuid/v4');
 
 const config = require('./config');
 const log = require('./logger');
@@ -34,6 +35,7 @@ app.get('/', function forwardRequestForStatistics(req, res, next) {
         headers: {
             'x-auth-username': req.get('x-auth-username'),
             'x-auth-userid': req.get('x-auth-userid'),
+            'x-correlation-id': uuid(),
             'Authorization': 'Basic ' + Buffer.from(IP_API_AUTH).toString('base64'),
         }
     };

--- a/server.test.js
+++ b/server.test.js
@@ -6,7 +6,7 @@ const request = require('supertest');
 const MOCK_CSV_RESPONSE = `From Date,To Date,Total Requests,Passed,Not Passed,Not Found,Error
 2019-01-01, 2019-01-31, 20, 15, 2, 2, 1`;
 
-const UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
+const UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
 
 const verifyOptions = function(capturedOptions) {
     assert.equal(capturedOptions.url, '/statistics');
@@ -15,7 +15,7 @@ const verifyOptions = function(capturedOptions) {
     assert.equal(capturedOptions.headers['x-auth-username'], 'some-username');
     assert.equal(capturedOptions.headers['x-auth-userid'], 'some-userid');
     assert(capturedOptions.headers.Authorization.startsWith('Basic '));
-    assert(capturedOptions.headers['x-correlation-id'].match(UUID_REGEX))
+    assert(capturedOptions.headers['x-correlation-id'].match(UUID_REGEX));
 };
 
 describe('Stats UI server', function() {

--- a/server.test.js
+++ b/server.test.js
@@ -6,6 +6,8 @@ const request = require('supertest');
 const MOCK_CSV_RESPONSE = `From Date,To Date,Total Requests,Passed,Not Passed,Not Found,Error
 2019-01-01, 2019-01-31, 20, 15, 2, 2, 1`;
 
+const UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/
+
 const verifyOptions = function(capturedOptions) {
     assert.equal(capturedOptions.url, '/statistics');
     assert.equal(capturedOptions.baseUrl, 'http://localhost:8081/');
@@ -13,6 +15,7 @@ const verifyOptions = function(capturedOptions) {
     assert.equal(capturedOptions.headers['x-auth-username'], 'some-username');
     assert.equal(capturedOptions.headers['x-auth-userid'], 'some-userid');
     assert(capturedOptions.headers.Authorization.startsWith('Basic '));
+    assert(capturedOptions.headers['x-correlation-id'].match(UUID_REGEX))
 };
 
 describe('Stats UI server', function() {


### PR DESCRIPTION
I have done this to make it easier to trace individual requests through Kibana. As it is such a small change I intend to merge and push through to production immediately.